### PR TITLE
Make nanoid compatible with Erlang < 20 and Elixir >= 1.4

### DIFF
--- a/lib/nanoid.ex
+++ b/lib/nanoid.ex
@@ -49,8 +49,8 @@ defmodule Nanoid do
   def generate(size, alphabet)
   def generate(size, alphabet) when is_integer(size) and size > 0 and is_binary(alphabet) and byte_size(alphabet) > 1 do
     alphabet_length = String.length(alphabet)
-    mask            = ((2 <<< round(:math.floor(:math.log(alphabet_length - 1) / :math.log(2)))) - 1)
-    step            = round(:math.ceil(1.6 * mask * size / alphabet_length))
+    mask            = ((2 <<< round(Float.floor(:math.log(alphabet_length - 1) / :math.log(2)))) - 1)
+    step            = round(Float.ceil(1.6 * mask * size / alphabet_length))
     do_generate(size, alphabet, mask, step)
   end
   def generate(size, alphabet)  when is_list(alphabet),

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Nanoid.Mixfile do
     [
       app: :nanoid,
       version: "1.0.0",
-      elixir: "~> 1.5",
+      elixir: "~> 1.4",
       start_permanent: Mix.env == :prod,
       description: description(),
       package: package(),


### PR DESCRIPTION
Elixir 1.4.x is still pretty popular in the wild and while it is possible to use nanoid with Elixir 1.4.x right now, you'd get a warning on compilation: 

```
warning: the dependency :nanoid requires Elixir "~> 1.5" but you are running on v1.4.5
```

Additionally AFAICT `:math.floor/1` and `:math.ceil/1` have only been added in Erlang 20.0 so nanoid doesn't work with earlier Erlang versions.

I tested the code in this PR with Erlang 18.x, 19.x and 20.x and Elixir 1.4.x and 1.5.x and it works just as expected.