### PR TITLE
Fix default size

### DIFF
--- a/lib/nanoid/configuration.ex
+++ b/lib/nanoid/configuration.ex
@@ -5,7 +5,7 @@ defmodule Nanoid.Configuration do
 
   ## -- DEFAULT ATTRIBUTES
   @default_mask 63
-  @default_size Application.get_env(:nanoid, :size, 1)
+  @default_size Application.get_env(:nanoid, :size, 21)
   @default_alphabet Application.get_env(:nanoid, :alphabet, "_-0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
   @default_alphabet_length String.length(@default_alphabet)
 


### PR DESCRIPTION
Default size of 21 was changed to 1 in 7f20f08, which seemed to be by
accident.