### PR TITLE
Use Application.get_env/3 calls instead of module attributes

### DIFF
--- a/lib/nanoid/configuration.ex
+++ b/lib/nanoid/configuration.ex
@@ -5,8 +5,8 @@ defmodule Nanoid.Configuration do
 
   ## -- DEFAULT ATTRIBUTES
   @default_mask 63
-  @default_size Application.get_env(:nanoid, :size, 21)
-  @default_alphabet Application.get_env(:nanoid, :alphabet, "_-0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+  @default_size 21
+  @default_alphabet "_-0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
   @default_alphabet_length String.length(@default_alphabet)
 
   @doc """
@@ -25,7 +25,7 @@ defmodule Nanoid.Configuration do
       21
   """
   @spec default_size :: Integer.t()
-  def default_size, do: @default_size
+  def default_size, do: Application.get_env(:nanoid, :size, @default_size)
 
   @doc """
   Returns the default alphabet of a nanoid used by the generators.
@@ -34,7 +34,7 @@ defmodule Nanoid.Configuration do
       "_-0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
   """
   @spec default_alphabet :: String.t()
-  def default_alphabet, do: @default_alphabet
+  def default_alphabet, do: Application.get_env(:nanoid, :alphabet, @default_alphabet)
 
   @doc """
   Returns the length of the default alphabet.


### PR DESCRIPTION
Module attributes are defined in compile time. I just happened to download and compile the application (which includes compiling NanoID as a dependency) and then change the config in my app to use a different size by default.

However, since the `@default_size` module attribute was defined when NanoID compiled, it wasn't having any effect. I had to explicitly recompile NanoID.

Instead of doing so, we can define the module attribute to be the fallback default value and use `Application.get_env/3` in runtime to get the value from the application config.

Note: I made this separate to #7 since this is an issue that might not necessarily be merged.