### PR TITLE
Fix Elixir 1.11 xref warnings

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule Nanoid.Mixfile do
   end
 
   def application do
-    []
+    [extra_applications: [:crypto]]
   end
 
   defp deps do


### PR DESCRIPTION
Fixes a warning on Elixir 1.11+. 

`warning: :crypto.strong_rand_bytes/1 defined in application :crypto is used by the current application but the current application does not directly depend on :crypto.`

Sorry for the multiple PRs today. Let me know if you have any questions or would like any changes. Thanks for maintaining a great library!