### PR TITLE
drop config dir

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,4 @@
 [
-  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  inputs: ["{mix,.formatter}.exs", "{lib,test}/**/*.{ex,exs}"],
   line_length: 140
 ]

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,5 +1,0 @@
-import Config
-
-config :nanoid,
-  size: 21,
-  alphabet: "_-0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"


### PR DESCRIPTION
Recent Elixir versions don't create `config` dir for `mix new app` so I guess it's "more idiomatic" to not have it if it's unnecessary :)

Note that the project would need to be rebuilt to fix `Application.compile_env` warnings due to `_build/dev/nanoid/ebin/nanoid.app` containing the "stale" config.

```console
$ mix compile
** (Mix) the application :nanoid has a different value set for key :alphabet during runtime compared to compile time. Since this application environment entry was marked as compile time, this difference can lead to different behaviour than expected:

  * Compile time value was set to: "_-0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
  * Runtime value was not set

To fix this error, you might:

  * Make the runtime value match the compile time one

  * Recompile your project. If the misconfigured application is a dependency, you may need to run "mix deps.clean nanoid --build"

  * Alternatively, you can disable this check. If you are using releases, you can set :validate_compile_env to false in your release configuration. If you are using Mix to start your system, you can pass the --no-validate-compile-env flag
$ rm _build
$ mix compile
==> earmark_parser
Compiling 3 files (.erl)
Compiling 46 files (.ex)
Generated earmark_parser app
==> nimble_parsec
Compiling 4 files (.ex)
Generated nimble_parsec app
==> makeup
Compiling 44 files (.ex)
Generated makeup app
==> makeup_elixir
Compiling 6 files (.ex)
Generated makeup_elixir app
==> makeup_erlang
Compiling 3 files (.ex)
Generated makeup_erlang app
==> ex_doc
Compiling 25 files (.ex)
Generated ex_doc app
==> earmark
Compiling 15 files (.ex)
Generated earmark app
==> nanoid
Compiling 4 files (.ex)
Generated nanoid app
```